### PR TITLE
Cosmetic changes to the `metadata.json` FROG report

### DIFF
--- a/offline-curator/app/cbmpycurator.py
+++ b/offline-curator/app/cbmpycurator.py
@@ -23,6 +23,15 @@ def hashFileMd5(fpath):
     print(digest)
     return digest
 
+def hashFileSha256(fpath):
+    sha_hash = hashlib.sha256()
+    a_file = open(fpath, 'rb')
+    content = a_file.read()
+    sha_hash.update(content)
+    digest = sha_hash.hexdigest()
+    print(digest)
+    return digest
+
 
 def readMetadata(fpath):
     with open(os.path.join(fpath, 'metadata.json'), 'r') as F:

--- a/offline-curator/offline_curator.py
+++ b/offline-curator/offline_curator.py
@@ -17,7 +17,7 @@ frog_curator = 'run-' + time.strftime('%m%d-%H%M')
 frog_date = time.strftime('%Y-%m-%d')
 
 
-def write_config(fpath, filename, frog_curator, frog_date, model_md5):
+def write_config(fpath, filename, frog_curator, frog_date, model_md5, model_sha256):
     config = {
         "frog_date": frog_date,
         "frog_version": "1.0",
@@ -40,6 +40,7 @@ def write_config(fpath, filename, frog_curator, frog_date, model_md5):
         },
         "model_filename": filename,
         "model_md5": model_md5,
+        "model_sha256": model_sha256,
         "environment": "{} {} ({})".format(platform.system(), platform.release(), platform.architecture()[0]),
     }
 
@@ -75,12 +76,13 @@ for m_ in model_files:
         os.makedirs(RESULT_DIR)
 
     model_md5 = CBCR.hashFileMd5(os.path.join(MODEL_DIR, m_))
+    model_sha256 = CBCR.hashFileSha256(os.path.join(MODEL_DIR, m_))
     import shutil
 
 
 
     if not os.path.exists(os.path.join(RESULT_DIR, 'metadata.json')):
-        write_config(RESULT_DIR, m_, frog_curator, frog_date, model_md5)
+        write_config(RESULT_DIR, m_, frog_curator, frog_date, model_md5, model_sha256)
 
     shutil.copyfile(os.path.join(MODEL_DIR, m_), os.path.join(RESULT_DIR, m_))
 

--- a/offline-curator/offline_curator.py
+++ b/offline-curator/offline_curator.py
@@ -20,23 +20,23 @@ frog_date = time.strftime('%Y-%m-%d')
 def write_config(fpath, filename, frog_curator, frog_date, model_md5, model_sha256):
     config = {
         "frog_date": frog_date,
-        "frog_version": "1.0",
+        "frog_version": "0.1.2",
         "frog_curators": [frog_curator],
-        "frog_software": {
-            "name": "cbmpyweb offline-curator",
-            "version": "0.1",
-            "url": "https://osf.io/t6mh3"
-        },
-
         "software": {
-            "name": "cbmpy",
-            "version": str(cbmpy.__version__),
-            "url": "https://systemsbioinformatics.github.io/cbmpy"
-        },
-        "solver": {
-            "name": "cbmpy",
-            "version": "0.1",
-            "url": ""
+            "frog": {
+                "name": "cbmpyweb offline-curator",
+                "version": "0.1",
+                "url": "https://osf.io/t6mh3"
+            },
+            "toolbox": {
+                "name": "cbmpy",
+                "version": str(cbmpy.__version__),
+                "url": "https://systemsbioinformatics.github.io/cbmpy"
+            },
+            "solver": {
+                "name": cbmpy.CBConfig.__CBCONFIG__['SOLVER_ACTIVE'],
+                "version": "unknown"
+            }
         },
         "model_filename": filename,
         "model_md5": model_md5,


### PR DESCRIPTION
Hello,
this contains small changes for being up-to-date with the frog spec here:
https://github.com/LCSB-BioCore/frog-specification

I was not able to test this yet (will need to install python and cbmpy first, hopefully asap next week). The changes are:
- the software is now grouped in a common sub-dict of the JSON so that it can be easily listed
- I changed the frog_version to match the spec
- I added the SHA256 hash for being future-proof
- the "software" is now separated between frog, toolbox and the solver. I don't know how to "get" the solver from CBMPy so the current variant is a guess; if there's any better way please let me know.

Please ping me if anything is visibly wrong; this is my first python written after like 2 years :sweat_smile: 

Thanks & best!
-mk

cc @stelmo @rsmsheriff @ntung