### PR TITLE
fix a missing parameter, fix `flux` column

### DIFF
--- a/offline-curator/app/cbmpycurator.py
+++ b/offline-curator/app/cbmpycurator.py
@@ -154,9 +154,7 @@ def testFVA(m, result_path, tool_id, sigfig=6, metadata=None, override_bin=cbmpy
                 mod_name,
                 m.getActiveObjective().getId(),
                 fids[r],
-                # my first choice is the flux value, but apparently the obj function value should be output
-                # round(fvals[r][0], sigfig),
-                obj_func_value,
+                round(fvals[r][0], sigfig),
                 solution_status,
                 round(fvals[r][2], sigfig),
                 round(fvals[r][3], sigfig),

--- a/offline-curator/offline_curator.py
+++ b/offline-curator/offline_curator.py
@@ -54,7 +54,7 @@ roundoff_num = 6
 TOOL_ID = 'cbmpy'
 
 
-write_config(MODEL_DIR, "", frog_curator, frog_date, "")
+write_config(MODEL_DIR, "", frog_curator, frog_date, "", "")
 
 if mfile is None:
     model_files = [m for m in os.listdir(MODEL_DIR) if m.endswith('.xml')]


### PR DESCRIPTION
@bgoli these problems somehow escaped the initial check, sorry. I also had no chance to test this because I don't have CPLEX handy (and GLPK is missing some functionality, see the error below) but I hope it should work.

commits:
1] at debugging I found I forgot to fix the 2nd call to write_config, that's ok now
2] the `flux` column semantics was originally correct -- I took the fixed version from your original code in the comment there, which was the correct one. During the discussion last autumn we simply found that this might be problematic to compare right but the only sensible choice, and (as usual) I didn't remember all of that correctly and messed stuff up.

Thanks again & best!
-mk

--------
The GLPK error:
```
[...]
OPTIMAL LP SOLUTION FOUND
0
LPS_OPT
Valid Presolution
Traceback (most recent call last):
  File "/home/exa/work/fbc-curation/cbmpy-web-curator/offline-curator/offline_curator.py", line 106, in <module>
    _ = CBCR.testFVA(testmod, RESULT_DIR, tool_id=TOOL_ID, sigfig=roundoff_num)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/exa/work/fbc-curation/cbmpy-web-curator/offline-curator/app/cbmpycurator.py", line 135, in testFVA
    fvals, fids = cbmpy.doFVA(m, optPercentage=100.0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/exa/work/fbc-curation/env/lib/python3.11/site-packages/cbmpy/CBGLPK.py", line 681, in glpk_FluxVariabilityAnalysis
    glpk_func_SetObjectiveFunctionAsConstraint(
  File "/home/exa/work/fbc-curation/env/lib/python3.11/site-packages/cbmpy/CBGLPK.py", line 968, in glpk_func_SetObjectiveFunctionAsConstraint
    for v_ in range(len(cpx.cols)):
                        ^^^^^^^^
AttributeError: 'SwigPyObject' object has no attribute 'cols'
```